### PR TITLE
Collect into a Result instead of map unwrap

### DIFF
--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -39,7 +39,7 @@ fn parse_multiple_lines() {
   let ast = parse("
     (print 1)
     (print 2)
-    (print 3)").map(|res| res.unwrap()).collect::<Vec<_>>();
+    (print 3)").collect::<Result<Vec<_>, _>>().unwrap();
 
   assert_eq!(ast, vec![
     lisp! { (print 1) },


### PR DESCRIPTION
This is more idiomatic (and marginally more efficient, I believe).

Also, I just wanted to let you know that I was very happy to have found your crate. It suits my use case spectacularly well and is beautifully minimal. Kudos.

Hopefully you'll see some more meaningful commits in the future :D