### PR TITLE
`BigInt` support and refactors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,52 @@
 version = 3
 
 [[package]]
+name = "autocfg"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "num-bigint"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "rust_lisp"
 version = "0.5.0"
+dependencies = [
+ "cfg-if",
+ "num-bigint",
+ "num-traits",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,19 @@ doc = true
 [[bin]]
 name = "rust_lisp"
 path = "src/main.rs"
+
+[features]
+# What integer to use for Value::Int
+bigint = ["num-bigint", "num-traits"]
+i128 = []
+i64 = []
+i16 = []
+i8 = []
+
+# Use f64 for Value::Float, if unset, use f32
+f64 = []
+
+[dependencies]
+cfg-if = "1.0"
+num-traits = { version = "0.2", optional = true }
+num-bigint = { version = "0.4", optional = true }

--- a/src/default_environment.rs
+++ b/src/default_environment.rs
@@ -248,14 +248,14 @@ pub fn default_env() -> Env {
                         .ok_or(RuntimeError::new("Failed converting `BigInt` to `usize`"))?
                     );
 
-                    while i <= end {
+                    while i < end {
                         res.push(i.clone());
                         i += 1;
                     }
 
                     Ok(Value::List(res.into_iter().map(Value::Int).collect::<List>()))
                 } else {
-                    Ok(Value::List((start..=end).map(Value::Int).collect::<List>()))
+                    Ok(Value::List((start..end).map(Value::Int).collect::<List>()))
                 }
             }
         }),

--- a/src/default_environment.rs
+++ b/src/default_environment.rs
@@ -200,6 +200,7 @@ pub fn default_env() -> Env {
         }),
     );
 
+    // 🦀 Oh the poor `filter`, you must feel really sad being unused.
     // entries.insert(
     //   String::from("filter"),
     //   Value::NativeFunc(

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -301,6 +301,7 @@ fn eval_inner(
 
     result
 }
+// 🦀 Boo! Did I scare ya? Haha!
 
 /// Calling a function is separated from the main `eval_inner()` function
 /// so that tail calls can be evaluated without just returning themselves

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,9 +15,10 @@ use model::Env;
 use std::io::Write;
 use std::{cell::RefCell, io, rc::Rc};
 
+
 /// Starts a REPL prompt at stdin/stdout. **This will block the current thread.**
 pub fn start_repl(env: Option<Env>) {
-    let env_rc = Rc::new(RefCell::new(env.unwrap_or(default_env())));
+    let env_rc = Rc::new(RefCell::new(env.unwrap_or_else(default_env)));
 
     loop {
         print!("> ");
@@ -26,7 +27,7 @@ pub fn start_repl(env: Option<Env>) {
         let mut buf = String::new();
         io::stdin().read_line(&mut buf).unwrap();
 
-        let res = eval_block(env_rc.clone(), parse(&buf).filter_map(|a| a.ok().clone()));
+        let res = eval_block(env_rc.clone(), parse(&buf).filter_map(|a| a.ok()));
 
         match res {
             Ok(val) => println!("{}", val),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ use std::io::Write;
 use std::{cell::RefCell, io, rc::Rc};
 
 
+// 🦀 I am all over this project!
 /// Starts a REPL prompt at stdin/stdout. **This will block the current thread.**
 pub fn start_repl(env: Option<Env>) {
     let env_rc = Rc::new(RefCell::new(env.unwrap_or_else(default_env)));

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -42,6 +42,7 @@ macro_rules! lisp {
     };
 
 
+    // 🦀 Very special!
     // Special atoms
     (Nil) => { Value::NIL };
     (T) =>   { Value::T   };

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,8 @@ use std::{cell::RefCell, rc::Rc};
 
 use rust_lisp::{default_env, eval_block, parse, start_repl};
 
+// 🦀 Try finding me! I'm hidden all around the code!
+
 fn main() {
     match std::env::args().nth(1) {
         Some(code) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ fn main() {
 
             println!(
                 "{}",
-                eval_block(env_rc.clone(), parse(&code).filter_map(|a| a.ok().clone())).unwrap()
+                eval_block(env_rc, parse(&code).filter_map(|a| a.ok())).unwrap()
             );
         }
         None => start_repl(None),

--- a/src/model.rs
+++ b/src/model.rs
@@ -146,6 +146,7 @@ impl Display for Value {
     }
 }
 
+// 🦀 Ferris blesses the Debug trait
 impl Debug for Value {
     fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
@@ -473,6 +474,8 @@ impl PartialEq for Lambda {
 /// The trait bound for any Rust function that is to be called from lisp code
 type NativeFunc = fn(env: Rc<RefCell<Env>>, args: &Vec<Value>) -> Result<Value, RuntimeError>;
 
+// 🦀 Ferris thinks... Maybe we should turn this struct into enum? Some things we can put in stack
+// rather than allocating memory for yet another `String`
 #[derive(Debug, Clone)]
 pub struct RuntimeError {
     pub msg: String,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,7 +1,8 @@
 use crate::{
     lisp,
-    model::{List, Value},
+    model::{List, Value, IntType, FloatType},
 };
+
 use std::fmt::Display;
 
 /// A slightly more convenient data structure for building the parse tree, before
@@ -40,7 +41,7 @@ impl ParseTree {
 }
 
 /// Tokenize Lisp code
-fn tokenize<'a>(code: &'a str) -> impl Iterator<Item = &'a str> {
+fn tokenize(code: &str) -> impl Iterator<Item = &str> {
     let mut skip_to: Option<usize> = None;
 
     code.char_indices().filter_map(move |(index, ch)| {
@@ -117,7 +118,7 @@ fn tokenize<'a>(code: &'a str) -> impl Iterator<Item = &'a str> {
             }
         }
 
-        return None;
+        None
     })
 }
 
@@ -292,10 +293,8 @@ fn read<'a>(
             ")" => {
                 parenths -= 1;
 
-                if stack.len() == 0 {
-                    Some(Err(ParseError {
-                        msg: format!("Unexpected ')'"),
-                    }))
+                if stack.is_empty() {
+                    Some(Err(ParseError::new("Unexpected ')'")))
                 } else {
                     let mut finished = stack.pop().unwrap();
 
@@ -307,7 +306,7 @@ fn read<'a>(
 
                         // () is Nil
                         if let ParseTree::List { vec, quoted } = &finished {
-                            if vec.len() == 0 {
+                            if vec.is_empty() {
                                 finished = ParseTree::Atom {
                                     atom: Value::NIL,
                                     quoted: *quoted,
@@ -331,12 +330,12 @@ fn read<'a>(
             _ => {
                 // atom
                 let expr = ParseTree::Atom {
-                    atom: read_atom(&token),
+                    atom: read_atom(token),
                     quoted: quote_next,
                 };
                 quote_next = false;
 
-                if stack.len() > 0 {
+                if !stack.is_empty() {
                     if let ParseTree::List { vec, quoted: _ } = stack.last_mut().unwrap() {
                         vec.push(expr);
                     }
@@ -364,14 +363,12 @@ fn read_atom(token: &str) -> Value {
         return Value::NIL;
     }
 
-    let as_int = token.parse::<i32>();
-    if as_int.is_ok() {
-        return Value::Int(as_int.unwrap());
+    if let Ok(as_int) = token.parse::<IntType>() {
+        return Value::Int(as_int);
     }
 
-    let as_float = token.parse::<f32>();
-    if as_float.is_ok() {
-        return Value::Float(as_float.unwrap());
+    if let Ok(as_float) = token.parse::<FloatType>() {
+        return Value::Float(as_float);
     }
 
     if token.chars().next().map_or(false, |c| c == '"')
@@ -380,7 +377,7 @@ fn read_atom(token: &str) -> Value {
         return Value::String(String::from(&token[1..token.chars().count() - 1]));
     }
 
-    return Value::Symbol(String::from(token));
+    Value::Symbol(String::from(token))
 }
 
 /// Parse a string of Lisp code into a series of s-expressions. There
@@ -394,6 +391,14 @@ pub fn parse(code: &str) -> impl Iterator<Item = Result<Value, ParseError>> + '_
 pub struct ParseError {
     pub msg: String,
     // pub line: i32,
+}
+
+impl ParseError {
+  fn new(s: impl Into<String>) -> ParseError {
+    ParseError {
+      msg: s.into()
+    }
+  }
 }
 
 impl Display for ParseError {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -336,8 +336,8 @@ fn read<'a>(
                 };
                 quote_next = false;
 
-                if !stack.is_empty() {
-                    if let ParseTree::List { vec, quoted: _ } = stack.last_mut().unwrap() {
+                if let Some(last) = stack.last_mut() {
+                    if let ParseTree::List { vec, quoted: _ } = last {
                         vec.push(expr);
                     }
                     None

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -155,6 +155,7 @@ fn tokenize_simplest() {
     assert_eq!(tokens, vec!["(", "1", "2", "3", ")"]);
 }
 
+// 🦀 Testing, testing!
 #[test]
 fn tokenize_basic_expression() {
     let source = "

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,6 @@
 use crate::model::{Value, RuntimeError, List, IntType, FloatType};
 
+// 🦀 Poor thing, you went unused too?
 // pub struct ArgumentError {
 //   msg: String,
 //   index: usize,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,4 @@
-use crate::model::{List, RuntimeError, Value};
+use crate::model::{Value, RuntimeError, List, IntType, FloatType};
 
 // pub struct ArgumentError {
 //   msg: String,
@@ -9,7 +9,7 @@ use crate::model::{List, RuntimeError, Value};
 /// and err if there isn't one.
 pub fn require_parameter<'a>(
     func_name: &str,
-    args: &'a Vec<Value>,
+    args: &'a [Value],
     index: usize,
 ) -> Result<&'a Value, RuntimeError> {
     match args.get(index) {
@@ -29,9 +29,9 @@ pub fn require_parameter<'a>(
 /// of this fails.
 pub fn require_int_parameter(
     func_name: &str,
-    args: &Vec<Value>,
+    args: &[Value],
     index: usize,
-) -> Result<i32, RuntimeError> {
+) -> Result<IntType, RuntimeError> {
     match require_parameter(func_name, args, index) {
         Ok(val) => match val.as_int() {
             Some(x) => Ok(x),
@@ -53,9 +53,9 @@ pub fn require_int_parameter(
 /// of this fails.
 pub fn require_float_parameter(
     func_name: &str,
-    args: &Vec<Value>,
+    args: &[Value],
     index: usize,
-) -> Result<f32, RuntimeError> {
+) -> Result<FloatType, RuntimeError> {
     match require_parameter(func_name, args, index) {
         Ok(val) => match val.as_float() {
             Some(x) => Ok(x),
@@ -77,7 +77,7 @@ pub fn require_float_parameter(
 /// String. Err if any part of this fails.
 pub fn require_string_parameter<'a>(
     func_name: &str,
-    args: &'a Vec<Value>,
+    args: &'a [Value],
     index: usize,
 ) -> Result<&'a str, RuntimeError> {
     match require_parameter(func_name, args, index) {
@@ -101,7 +101,7 @@ pub fn require_string_parameter<'a>(
 /// the case.
 pub fn require_list_parameter<'a>(
     func_name: &str,
-    args: &'a Vec<Value>,
+    args: &'a [Value],
     index: usize,
 ) -> Result<&'a List, RuntimeError> {
     match require_parameter(func_name, args, index) {


### PR DESCRIPTION
Added `BigInt` support, along with compile-time configurable types for `Value::Int` and `Value::Float`. I did some code refactoring in form of adding `new(impl Into<String>)` method to error types and changing manual error constructions with constructions with the said `new` method. Also, I've added `factorial` function in order to test `BigInt`, but to be honest I just like seeing big numbers draw over my screen :D

In order to do some of the crazy shit I did in order to make `BigInt` work nicely (and kill readability), I added `cfg-if`, `num-traits` and `num-bigint` as dependencies. The `num-traits` and `num-bigint` are compiled _if_ and only _if_ feature `bigint` is set. I am relatively new to Rust and if you have any suggestions and/or corrections, I'd like to hear them!