### PR TITLE
REPL fix & smol refactors

### DIFF
--- a/src/default_environment.rs
+++ b/src/default_environment.rs
@@ -243,7 +243,7 @@ pub fn default_env() -> Env {
                     let end = end.to_i128().ok_or(RuntimeError::new("Failed converting to `i128`"))?;
                 }
             }
-            
+
             Ok(Value::List(
                 (start..end).map(Value::from_int).collect::<List>(),
             ))

--- a/src/default_environment.rs
+++ b/src/default_environment.rs
@@ -212,7 +212,7 @@ pub fn default_env() -> Env {
                     }
                 })
                 .collect::<Result<List, RuntimeError>>()
-                .map(|l| Value::List(l))
+                .map(Value::List)
         }),
     );
 

--- a/src/default_environment.rs
+++ b/src/default_environment.rs
@@ -5,7 +5,7 @@ use crate::{
     utils::{require_int_parameter, require_list_parameter, require_parameter},
 };
 use cfg_if::cfg_if;
-use std::{collections::HashMap, convert::TryInto};
+use std::{collections::HashMap, convert::TryInto, rc::Rc};
 cfg_if! {
     if #[cfg(feature = "bigint")] {
         use num_traits::ToPrimitive;
@@ -184,7 +184,7 @@ pub fn default_env() -> Env {
                 .map(|val| {
                     let expr = lisp! { ({func.clone()} {val}) };
 
-                    eval(env.clone(), &expr)
+                    eval(Rc::clone(&env), &expr)
                 })
                 .collect::<Result<List, RuntimeError>>()
                 .map(Value::List)
@@ -201,7 +201,7 @@ pub fn default_env() -> Env {
             list.into_iter()
                 .filter_map(|val: Value| -> Option<Result<Value, RuntimeError>> {
                     let expr = Value::List([func.clone(), val.clone()].iter().collect());
-                    let res = eval(env.clone(), &expr);
+                    let res = eval(Rc::clone(&env), &expr);
 
                     match res {
                         Ok(matches) => match matches.is_truthy() {

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -36,7 +36,11 @@ fn eval_block_inner(
         current_expr = Some(clause);
     }
 
-    eval_inner(env, &current_expr.unwrap(), found_tail, in_func)
+    if let Some(expr) = &current_expr {
+        eval_inner(env, expr, found_tail, in_func)
+    } else {
+        Err(RuntimeError::new("Unrecognized expression"))
+    }
 }
 
 /// `found_tail` and `in_func` are used when locating the tail position for

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,11 +22,10 @@ use std::{cell::RefCell, rc::Rc};
 /// Starts a REPL prompt at stdin/stdout. **This will block the current thread.**
 pub fn start_repl(env: Option<Env>) {
     let env = Rc::new(RefCell::new(env.unwrap_or_else(default_env)));
-    let stdin = io::stdin();
 
     print!("> ");
     io::stdout().flush().unwrap();
-    for line in stdin.lock().lines() {
+    for line in io::stdin().lock().lines() {
         match eval_block(Rc::clone(&env), parse(&line.unwrap()).filter_map(|a| a.ok())) {
             Ok(val) => println!("{}", val),
             Err(e) => println!("{}", e),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,26 +12,24 @@ pub mod utils;
 pub mod macros;
 
 use model::Env;
-use std::io::Write;
-use std::{cell::RefCell, io, rc::Rc};
+use std::io::{self, prelude::*};
+use std::{cell::RefCell, rc::Rc};
 
 // 🦀 I am all over this project!
 /// Starts a REPL prompt at stdin/stdout. **This will block the current thread.**
 pub fn start_repl(env: Option<Env>) {
     let env_rc = Rc::new(RefCell::new(env.unwrap_or_else(default_env)));
+    let stdin = io::stdin();
 
-    loop {
-        print!("> ");
-        io::stdout().flush().unwrap();
-
-        let mut buf = String::new();
-        io::stdin().read_line(&mut buf).unwrap();
-
-        let res = eval_block(env_rc.clone(), parse(&buf).filter_map(|a| a.ok()));
-
-        match res {
+    print!("> ");
+    io::stdout().flush().unwrap();
+    for line in stdin.lock().lines() {
+        match eval_block(env_rc.clone(), parse(&line.unwrap()).filter_map(|a| a.ok())) {
             Ok(val) => println!("{}", val),
             Err(e) => println!("{}", e),
         };
+
+        print!("> ");
+        io::stdout().flush().unwrap();
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
+#![forbid(unsafe_code)]
+#![warn(clippy::clone_on_ref_ptr)]
+
 mod default_environment;
 mod interpreter;
 mod parser;
@@ -18,13 +21,13 @@ use std::{cell::RefCell, rc::Rc};
 // 🦀 I am all over this project!
 /// Starts a REPL prompt at stdin/stdout. **This will block the current thread.**
 pub fn start_repl(env: Option<Env>) {
-    let env_rc = Rc::new(RefCell::new(env.unwrap_or_else(default_env)));
+    let env = Rc::new(RefCell::new(env.unwrap_or_else(default_env)));
     let stdin = io::stdin();
 
     print!("> ");
     io::stdout().flush().unwrap();
     for line in stdin.lock().lines() {
-        match eval_block(env_rc.clone(), parse(&line.unwrap()).filter_map(|a| a.ok())) {
+        match eval_block(Rc::clone(&env), parse(&line.unwrap()).filter_map(|a| a.ok())) {
             Ok(val) => println!("{}", val),
             Err(e) => println!("{}", e),
         };

--- a/src/model.rs
+++ b/src/model.rs
@@ -265,6 +265,7 @@ impl PartialOrd for Value {
             },
             Value::Float(n) => match other {
                 Value::Int(o) => {
+                    #[allow(clippy::needless_late_init)]
                     let o_float: FloatType;
 
                     // At these situations I think to myself that adding support for BigInt was a
@@ -338,16 +339,17 @@ mod list {
                     msg: String::from("Attempted to apply car on nil"),
                 })
         }
+        #[must_use]
         pub fn cdr(&self) -> List {
             List {
                 head: self
                     .head
                     .as_ref()
-                    .map(|rc| rc.borrow().cdr.as_ref().cloned())
-                    .flatten(),
+                    .and_then(|rc| rc.borrow().cdr.as_ref().cloned()),
             }
         }
 
+        #[must_use]
         pub fn cons(&self, val: Value) -> List {
             List {
                 head: Some(Rc::new(RefCell::new(ConsCell {

--- a/src/model.rs
+++ b/src/model.rs
@@ -444,10 +444,10 @@ mod list {
 
                 // if this is the first cell, put it in the List
                 if new_list.head.is_none() {
-                    new_list.head = Some(new_cons.clone());
+                    new_list.head = Some(Rc::clone(&new_cons));
                 // otherwise, put it in the current tail cell
                 } else if let Some(tail_cons) = tail {
-                    tail_cons.as_ref().borrow_mut().cdr = Some(new_cons.clone());
+                    tail_cons.as_ref().borrow_mut().cdr = Some(Rc::clone(&new_cons));
                 }
 
                 // the current cell is the new tail


### PR DESCRIPTION
I did smol (opinionated) refactoring. I kind of only wanted to fix the REPL thing where it errors out upon pressing Ctrl-D, which is not supposed to happen since Ctrl-D is for terminating, but I ended up refactoring some code.

The explicit Rc clones is there because I think it makes incrementing the reference counter more explicit, but it's just my opinion, I'll remove it if you think it's not needed.