### PR TITLE
REPL Ctrl-D termination, unclosed string handling and other refactors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ description = "A Rust-embeddable Lisp, with support for interop with native Rust
 version = "0.6.0"
 authors = ["Brandon Smith"]
 repository = "https://github.com/brundonsmith/rust_lisp"
-edition = "2018"
+edition = "2021"
 exclude = [".github", ".vscode", "TODO.txt"]
 license = "MIT"
 

--- a/src/default_environment.rs
+++ b/src/default_environment.rs
@@ -243,7 +243,7 @@ pub fn default_env() -> Env {
                     let end = end.to_i128().ok_or(RuntimeError::new("Failed converting to `i128`"))?;
                 }
             }
-            
+
             Ok(Value::List(
                 (start..end).map(Value::from_int).collect::<List>(),
             ))

--- a/src/default_environment.rs
+++ b/src/default_environment.rs
@@ -212,7 +212,7 @@ pub fn default_env() -> Env {
                     }
                 })
                 .collect::<Result<List, RuntimeError>>()
-                .map(|l| Value::List(l))
+                .map(Value::List)
         }),
     );
 

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -36,7 +36,11 @@ fn eval_block_inner(
         current_expr = Some(clause);
     }
 
-    eval_inner(env, &current_expr.unwrap(), found_tail, in_func)
+    if let Some(expr) = &current_expr {
+        eval_inner(env, expr, found_tail, in_func)
+    } else {
+        Err(RuntimeError::new("Unrecognized expression"))
+    }
 }
 
 /// `found_tail` and `in_func` are used when locating the tail position for

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![forbid(unsafe_code)]
+
 mod default_environment;
 mod interpreter;
 mod parser;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,26 +12,26 @@ pub mod utils;
 pub mod macros;
 
 use model::Env;
-use std::io::Write;
-use std::{cell::RefCell, io, rc::Rc};
+use std::io::{self, prelude::*};
+use std::{cell::RefCell, rc::Rc};
 
 // 🦀 I am all over this project!
 /// Starts a REPL prompt at stdin/stdout. **This will block the current thread.**
 pub fn start_repl(env: Option<Env>) {
     let env_rc = Rc::new(RefCell::new(env.unwrap_or_else(default_env)));
 
-    loop {
-        print!("> ");
-        io::stdout().flush().unwrap();
-
-        let mut buf = String::new();
-        io::stdin().read_line(&mut buf).unwrap();
-
-        let res = eval_block(env_rc.clone(), parse(&buf).filter_map(|a| a.ok()));
-
-        match res {
+    print!("> ");
+    io::stdout().flush().unwrap();
+    for line in io::stdin().lock().lines() {
+        match eval_block(env_rc.clone(), parse(&line.unwrap()).filter_map(|a| a.ok())) {
             Ok(val) => println!("{}", val),
             Err(e) => println!("{}", e),
         };
+
+        print!("> ");
+        io::stdout().flush().unwrap();
     }
+
+    // Properly go to the next line after quitting
+    println!();
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -265,6 +265,7 @@ impl PartialOrd for Value {
             },
             Value::Float(n) => match other {
                 Value::Int(o) => {
+                    #[allow(clippy::needless_late_init)]
                     let o_float: FloatType;
 
                     // At these situations I think to myself that adding support for BigInt was a
@@ -338,16 +339,17 @@ mod list {
                     msg: String::from("Attempted to apply car on nil"),
                 })
         }
+        #[must_use]
         pub fn cdr(&self) -> List {
             List {
                 head: self
                     .head
                     .as_ref()
-                    .map(|rc| rc.borrow().cdr.as_ref().cloned())
-                    .flatten(),
+                    .and_then(|rc| rc.borrow().cdr.as_ref().cloned()),
             }
         }
 
+        #[must_use]
         pub fn cons(&self, val: Value) -> List {
             List {
                 head: Some(Rc::new(RefCell::new(ConsCell {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -375,13 +375,7 @@ fn read_atom(token: &str) -> Value {
     }
 
     if token.chars().next().map_or(false, |c| c == '"') {
-        // Empty string edge-case
-        if token.chars().nth(1).map_or(false, |c| c == '"') {
-            return Value::String(String::from(""));
-        }
-
         // TODO: Implement escaped characters
-
         return Value::String(String::from(&token[1..token.chars().count() - 1]));
     }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -81,11 +81,12 @@ fn tokenize(code: &str) -> impl Iterator<Item = &str> {
         }
 
         // comments
-        if ch == ';' && code[index + 1..].chars().next().map_or(false, |c| c == ';') {
-            let comment_end =
-                index + 2 + match_pred(&code[index + 2..], |c| c != '\n').unwrap_or(0);
-
-            skip_to = Some(comment_end + 1);
+        if ch == ';' {
+            if let Some(newline_index) = code[index..].find(|c| c == '\n') {
+                skip_to = Some(index + newline_index + 1);
+            } else {
+                skip_to = Some(code.len());
+            }
             return None;
         }
 


### PR DESCRIPTION
After I've read your [blog](https://www.brandons.me/blog/favorite-rust-function), I decided to check on `parser.rs` and found out how simple it actually is, which amazed me. I like the blogs, keep it up.

I did following things in this PR:
- Made REPL close on Ctrl-D (at least on Linux)
- Handled unclosed strings properly so it doesn't panic
- Allowed single semicolon comments
- Bumped Rust edition (2018 -> 2021)
- Did some general refactoring