### PR TITLE
:bug: Fix closures being ignored

### DIFF
--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -353,7 +353,7 @@ fn call_function(
             }
 
             let arg_env = Rc::new(RefCell::new(Env {
-                parent: Some(env),
+                parent: Some(lamb.closure.clone()),
                 entries,
             }));
 

--- a/tests/interpreter.rs
+++ b/tests/interpreter.rs
@@ -225,6 +225,17 @@ fn calling_empty_fun() {
     assert_eq!(result, lisp! { () });
 }
 
+#[test]
+fn closure() {
+    let result = eval_str(
+        "
+    (map (let ((x 3)) (lambda (y) (+ x y))) (list 0 1 2 3 4))
+        "
+    );
+    
+    assert_eq!(result, lisp! {(3 4 5 6 7)});
+}
+
 #[cfg(test)]
 fn eval_str(source: &str) -> Value {
     let ast = parse(source).next().unwrap().unwrap();


### PR DESCRIPTION
Prior to this pull request, closures in lambdas were ignored. This can be seen when running `grep -Rn "closure" src/`:

```
src/interpreter.rs:146:                        closure: env.clone(),
src/interpreter.rs:162:                        closure: env,
src/model.rs:471:    pub closure: Rc<RefCell<Env>>,
src/model.rs:478:        self.closure.as_ptr() == other.closure.as_ptr()
src/model.rs:513:/// closures, for `let` statements, for function arguments, etc.
```

The `closure` field is never read, except when testing for equality.
When a lambda is called, the environment of the caller's site is injected into the lambda's environment instead; this means that captured variables are discarded.
The following piece of code is affected by this issue:

```lisp
(map (let ((x 3)) (lambda (y) (+ x y))) (list 0 1 2 3 4))
```

**Expected:** `(3 4 5 6 7)`
**Actual:** `Runtime error: Function "+" requires an argument 2`

This pull request fixes that by injecting the lambda's stored closure instead of the caller's environment, and introduces the above piece of code as a test.