### PR TITLE
Fix panic on invalid function syntax

### DIFF
--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -140,6 +140,28 @@ fn eval_inner(
                             symbol
                         ),
                     })?);
+
+                    // Verify that argnames is a list
+                    if let Some(arglist) = argnames.as_list() {
+                        // Verify that arglist only contains symbols
+                        if let Some(non_argname) = arglist.into_iter().find(|a| !a.as_symbol().is_some()) {
+                            return Err(RuntimeError {
+                                msg: format!(
+                                    "Argument names in function definition for \"{}\" should only contain symbols, got {}",
+                                    symbol,
+                                    non_argname
+                                ),
+                            });
+                        }
+                    } else {
+                        return Err(RuntimeError {
+                            msg: format!(
+                                "Expected argument list in function definition for \"{}\", got {}",
+                                symbol,
+                                argnames
+                            )
+                        });
+                    }
                     let body = Rc::new(Value::List(list_iter.collect::<List>()));
 
                     let lambda = Value::Lambda(Lambda {
@@ -156,6 +178,26 @@ fn eval_inner(
                 Value::Symbol(symbol) if symbol == "lambda" => {
                     let cdr = list.cdr();
                     let argnames = Rc::new(cdr.car()?);
+                    // Verify that argnames is a list
+                    if let Some(arglist) = argnames.as_list() {
+                        // Verify that arglist only contains symbols
+                        if let Some(non_argname) = arglist.into_iter().find(|a| !a.as_symbol().is_some()) {
+                            return Err(RuntimeError {
+                                msg: format!(
+                                    "Argument names in lambda definition should only contain symbols, got {}",
+                                    non_argname
+                                ),
+                            });
+                        }
+                    } else {
+                        return Err(RuntimeError {
+                            msg: format!(
+                                "Expected argument list in lambda definition, got {}",
+                                argnames
+                            )
+                        });
+                    }
+                    
                     let body = Rc::new(Value::List(cdr.cdr()));
 
                     Ok(Value::Lambda(Lambda {

--- a/tests/interpreter.rs
+++ b/tests/interpreter.rs
@@ -226,6 +226,18 @@ fn calling_empty_fun() {
 }
 
 #[test]
+#[should_panic]
+fn invalid_fun() {
+    eval_str("(defun my_fn (3) 3)");
+}
+
+#[test]
+#[should_panic]
+fn invalid_lambda() {
+    eval_str("(lambda (3) 3)");
+}
+
+#[test]
 fn closure() {
     let result = eval_str(
         "


### PR DESCRIPTION
When constructing a `Lambda` instance in `src/interpreter.rs`, the value for `argnames` is not checked.
This later causes an assertion error, as `argnames` is expected to be a `List` containing only `Symbol`s.
The following piece of code demonstrates this issue:

```lisp
((lambda (3) 3))
```

**Expected:** The interpreter should return an `Err`, explaining that `3` is not a valid symbol for a function's argument
**Actual:**
```
thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', src/interpreter.rs:336:49
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
**With this PR:** `Runtime error: Argument names in function definition for "lambda" should only contain symbols, got 3`

This PR fixes that, by introducing the requirement for `argnames` to be a `List` of `Symbol`s as a class invariant for `Lambda`.
This invariant is enforced on the creation of a new `Lambda` instance, and the `argnames` field has been made private and is now read-only through the new `argnames()` method.

The check in this PR is also catches instances of this issue that may seem less obvious, like `(lambda (f) (f 3))`: here `f` is interpreted as `Value::False`, which triggers the error message.

## Notes

I see two reasons to reject this PR:
- it is a breaking change, so any code that was previously creating `Lambda` instances by hand will need to get addressed
- it may not be desirable to have the above integrity requirement as a class invariant; this may for instance get in the way of pattern matching. The first commit of this PR presents a version where the check was made before constructing a `Lambda` instance