### PR TITLE
Add docs.rs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![Rust](https://github.com/brundonsmith/rust-lisp/workflows/Rust/badge.svg)
-![docs.rs](https://img.shields.io/docsrs/rust_lisp/latest)
+[![docs.rs](https://img.shields.io/docsrs/rust_lisp/latest)](https://docs.rs/rust_lisp/latest/rust_lisp/)
 
 # What is this?
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-![Rust](https://github.com/brundonsmith/rust-lisp/workflows/Rust/badge.svg)
+[![GitHub Workflow Status](https://img.shields.io/github/workflow/status/brundonsmith/rust_lisp/Rust)](https://github.com/brundonsmith/rust_lisp/actions)
+[![rust_lisp shield](https://img.shields.io/crates/v/rust_lisp)](https://crates.io/crates/rust_lisp)
 [![docs.rs](https://img.shields.io/docsrs/rust_lisp/latest)](https://docs.rs/rust_lisp/latest/rust_lisp/)
 
 # What is this?

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 ![Rust](https://github.com/brundonsmith/rust-lisp/workflows/Rust/badge.svg)
+![docs.rs](https://img.shields.io/docsrs/rust_lisp/latest)
 
 # What is this?
 


### PR DESCRIPTION
Hi there! Noticed that `docs.rs` generation for this seems to be working fine, so I figured it'd be a good idea to add the relevant shield to the README. (I use it to quickly glance at the docs for a library.)

edit: apologies for the second commit, realised after making the first commit that `shields.io`'s Markdown does not actually include the link to the docs. Ah well.