### PR TITLE
Add environment state map

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "erased_set"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a5aa24577083f8190ad401e376b55887c7cd9083ae95d83ceec5d28ea78125"
+
+[[package]]
 name = "num-bigint"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -49,6 +55,7 @@ name = "rust_lisp"
 version = "0.16.1"
 dependencies = [
  "cfg-if",
+ "erased_set",
  "num-bigint",
  "num-traits",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,11 +25,13 @@ i128 = []
 i64 = []
 i16 = []
 i8 = []
+state = [ "erased_set" ]
 
 # Use f64 for Value::Float, if unset, use f32
 f64 = []
 
 [dependencies]
 cfg-if = "1.0"
+erased_set = { version = "0.7", optional = true }
 num-traits = { version = "0.2", optional = true }
 num-bigint = { version = "0.4", optional = true }


### PR DESCRIPTION
This provides the `Env` with the ability to attach arbitrary state instances to be retrieved later on, without exposing them to the actual runtime environment. Surprised that this wasn't a feature already, perhaps I missed something obvious. This allows applications to host the runtime and use it more like a scripting engine.