### PR TITLE
Add optional libm feature.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,10 +26,14 @@ i64 = []
 i16 = []
 i8 = []
 
+# Use in environments where the linker can't find libm.
+libm = ["dep:libm"]
+
 # Use f64 for Value::Float, if unset, use f32
 f64 = []
 
 [dependencies]
 cfg-if = "1.0"
+libm = { version = "0.2", optional = true }
 num-traits = { version = "0.2", optional = true }
 num-bigint = { version = "0.4", optional = true }

--- a/src/model/value.rs
+++ b/src/model/value.rs
@@ -422,6 +422,8 @@ impl PartialOrd for Value {
                     cfg_if! {
                         if #[cfg(feature = "bigint")] {
                             n.partial_cmp(&BigInt::from(o.round() as i64))
+                        } else if #[cfg(feature = "libm")] {
+                            n.partial_cmp(&(libm::roundf(*o) as IntType))
                         } else {
                             n.partial_cmp(&(o.round() as IntType))
                         }


### PR DESCRIPTION
In some environments, e.g. non-standard OSes, libm C library might be missing, and the linker complains that it can't find roundf. Using the standard (Rust-project supported) libm in these situations resolves the issue.