### PR TITLE
Allow multiple multipliers.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "libm"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
+
+[[package]]
 name = "num-bigint"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -49,6 +55,7 @@ name = "rust_lisp"
 version = "0.16.1"
 dependencies = [
  "cfg-if",
+ "libm",
  "num-bigint",
  "num-traits",
 ]

--- a/src/default_environment.rs
+++ b/src/default_environment.rs
@@ -395,26 +395,54 @@ pub fn default_env() -> Env {
     env.define(
         Symbol::from("*"),
         Value::NativeFunc(|_env, args| {
-            let a = require_arg("*", args, 0)?;
-            let b = require_arg("*", args, 1)?;
-
-            if let (Ok(a), Ok(b)) = (
-                TryInto::<IntType>::try_into(a),
-                TryInto::<IntType>::try_into(b),
-            ) {
-                return Ok(Value::Int(a * b));
+            if args.len() < 2 {
+                return Err(RuntimeError {
+                    msg: String::from("Function \"*\" requires at least two numeric arguments"),
+                });
             }
 
-            if let (Ok(a), Ok(b)) = (
-                TryInto::<FloatType>::try_into(a),
-                TryInto::<FloatType>::try_into(b),
-            ) {
-                return Ok(Value::Float(a * b));
+            let mut product = Value::Int(1);
+
+            for arg in args {
+                product = match arg {
+                    Value::Int(x) => match product {
+                        Value::Int(t) => Value::Int(t * x.clone()),
+                        Value::Float(t) => {
+                            cfg_if! {
+                                if #[cfg(feature = "bigint")] {
+                                    Value::Float(t * x.to_i128().unwrap() as FloatType)
+                                } else {
+                                    Value::Float(t * *x as FloatType)
+                                }
+                            }
+                        }
+                        _ => unreachable!("Will only ever assign int/float to `product`"),
+                    },
+                    Value::Float(x) => match product {
+                        Value::Int(t) => {
+                            cfg_if! {
+                                if #[cfg(feature = "bigint")] {
+                                    Value::Float(t.to_i128().unwrap() as FloatType * *x)
+                                } else {
+                                    Value::Float(t as FloatType * *x)
+                                }
+                            }
+                        }
+                        Value::Float(t) => Value::Float(t * *x),
+                        _ => unreachable!("Will only ever assign int/float to `product`"),
+                    },
+                    _ => {
+                        return Err(RuntimeError {
+                            msg: format!(
+                                "Function \"+\" requires arguments to be numbers; found {}",
+                                arg
+                            ),
+                        });
+                    }
+                };
             }
 
-            Err(RuntimeError {
-                msg: String::from("Function \"*\" requires arguments to be numbers"),
-            })
+            Ok(product)
         }),
     );
 

--- a/src/default_environment.rs
+++ b/src/default_environment.rs
@@ -395,12 +395,6 @@ pub fn default_env() -> Env {
     env.define(
         Symbol::from("*"),
         Value::NativeFunc(|_env, args| {
-            if args.len() < 2 {
-                return Err(RuntimeError {
-                    msg: String::from("Function \"*\" requires at least two numeric arguments"),
-                });
-            }
-
             let mut product = Value::Int(1);
 
             for arg in args {

--- a/src/default_environment.rs
+++ b/src/default_environment.rs
@@ -434,7 +434,7 @@ pub fn default_env() -> Env {
                     _ => {
                         return Err(RuntimeError {
                             msg: format!(
-                                "Function \"+\" requires arguments to be numbers; found {}",
+                                "Function \"*\" requires arguments to be numbers; found {}",
                                 arg
                             ),
                         });

--- a/tests/interpreter.rs
+++ b/tests/interpreter.rs
@@ -2,7 +2,7 @@ use rust_lisp::{
     default_env,
     interpreter::eval,
     lisp,
-    model::{IntType, RuntimeError, Symbol, Value},
+    model::{FloatType, IntType, RuntimeError, Symbol, Value},
     parser::parse,
 };
 use std::{cell::RefCell, rc::Rc};
@@ -12,6 +12,27 @@ fn eval_basic_expression() {
     let result = eval_str("(+ (* 1 2) (/ 6 3))");
 
     assert_eq!(result, Value::from(Into::<IntType>::into(4)));
+}
+
+#[test]
+fn eval_add_list() {
+    let result = eval_str("(+ 1 2 3 4)");
+
+    assert_eq!(result, Value::from(Into::<IntType>::into(10)));
+}
+
+#[test]
+fn eval_mul_list_ints() {
+    let result = eval_str("(* 1 2 3 4)");
+
+    assert_eq!(result, Value::from(Into::<IntType>::into(24)));
+}
+
+#[test]
+fn eval_mul_list_mixed() {
+    let result = eval_str("(* 1 2.0 3.0 4)");
+
+    assert_eq!(result, Value::from(Into::<FloatType>::into(24.0)));
 }
 
 #[test]


### PR DESCRIPTION
Currently, only two multipliers are allowed. But it is common for a lisp program to have (* N1 N2 N3 N4) expressions. Moreover, (+ N1 N2 N3 N4) expressions are already supported.