### PR TITLE
Add comparable type codes to Value

### DIFF
--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -37,4 +37,4 @@ pub use lambda::Lambda;
 pub use list::List;
 pub use runtime_error::RuntimeError;
 pub use symbol::Symbol;
-pub use value::{ForeignValue, ForeignValueRc, HashMapRc, NativeFunc, Value};
+pub use value::{ForeignValue, ForeignValueRc, HashMapRc, NativeFunc, Type, Value};


### PR DESCRIPTION
This allows a `Value` to decay to a `Type` via `Value::ty()` (named such since otherwise it'd have to be `Value::r#type()`). It's useful for a variety of typechecking casees.

This will conflict with #25 a bit, so either this PR or the other one will need to be updated when the opposite lands.