### PR TITLE
Add Value::Opaque type

### DIFF
--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -37,4 +37,4 @@ pub use lambda::Lambda;
 pub use list::List;
 pub use runtime_error::RuntimeError;
 pub use symbol::Symbol;
-pub use value::{ForeignValue, ForeignValueRc, HashMapRc, NativeFunc, Value};
+pub use value::{ForeignValue, ForeignValueRc, HashMapRc, NativeFunc, OpaqueValueRc, Value};


### PR DESCRIPTION
This allows the host application to pass around references to Rust objects without allowing the Lisp environment to interact with them (as `Foreign` specifies, for example).

I've gone back and forth about whether or not it's a good idea to allow true `Any` (which means any non-crate types) so any opinions would be cool :) If not, then the `OpaqueValue` trait can go away.